### PR TITLE
created and used img.full-width css class

### DIFF
--- a/_portfolio/edel.md
+++ b/_portfolio/edel.md
@@ -8,16 +8,19 @@ layout: portfolio-item
 
 In this project, I re-branded Izze's sparkling apple drink to fit a new target audience: young adults who don't drink alcohol but still want feel upperclass. The idea behind the design was to connect apples with its symbolic roots so I created a design which communicated divinity through its use of gold and white colors, Alphonse Mucha-like decorative swirls, and references to 15th century calligraphy.
 
-![Adriana Belinski]({{ "/assets/images/edel8.jpg" | relative_url }}){:class="centered" width="1000px"}
+![Adriana Belinski]({{ "/assets/images/edel8.jpg" | relative_url }}){:class="full-width"}
 
-![Adriana Belinski]({{ "/assets/images/edel4.jpg" | relative_url }}){:class="centered" width="1000px"}
+![Adriana Belinski]({{ "/assets/images/edel4.jpg" | relative_url }}){:class="full-width"}
+
 In the front of the bottle, I laser cut a white label and at the back of each bottle is a bizarre image of houses tumbling and breaking into each other which plays on the idea of distortion usually caused by alcoholic drinks.
 
-![Adriana Belinski]({{ "/assets/images/edel5.jpg" | relative_url }}){:class="centered" width="1000px"}
+![Adriana Belinski]({{ "/assets/images/edel5.jpg" | relative_url }}){:class="full-width"}
+
 The backside of the bottle features monsters that were believed to have existed in the 15th century. These pictures were taken from a book called the Nuremberg chronicles which contains the cumulative knowledge of what the people of Germany knew about the world.
-![Adriana Belinski]({{ "/assets/images/edel6.jpg" | relative_url }}){:class="centered" width="1000px"}
-![Adriana Belinski]({{ "/assets/images/edel7.jpg" | relative_url }}){:class="centered" width="600px"}
-![Adriana Belinski]({{ "/assets/images/edel9.jpg" | relative_url }}){:class="centered" width="1000px"}
-![Adriana Belinski]({{ "/assets/images/edel.jpg" | relative_url }}){:class="centered" width="1000px"}
-![Adriana Belinski]({{ "/assets/images/edel2.jpg" | relative_url }}){:class="centered" width="1000px"}
-![Adriana Belinski]({{ "/assets/images/edel3.jpg" | relative_url }}){:class="centered" width="1000px"}
+
+![Adriana Belinski]({{ "/assets/images/edel6.jpg" | relative_url }}){:class="full-width"}
+![Adriana Belinski]({{ "/assets/images/edel7.jpg" | relative_url }}){:class="centered" style="width: 60%"}
+![Adriana Belinski]({{ "/assets/images/edel9.jpg" | relative_url }}){:class="full-width"}
+![Adriana Belinski]({{ "/assets/images/edel.jpg" | relative_url }}){:class="full-width"}
+![Adriana Belinski]({{ "/assets/images/edel2.jpg" | relative_url }}){:class="full-width"}
+![Adriana Belinski]({{ "/assets/images/edel3.jpg" | relative_url }}){:class="full-width"}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -20,6 +20,11 @@ img.centered {
   margin: auto;
 }
 
+img.full-width {
+  display: block;
+  width: 100%;
+}
+
 img.rounded {
   border-radius: 50%;
 }


### PR DESCRIPTION
In this pull request, I added a `full-width` CSS class which can be used on img elements. Adding `full-width` to an img element makes that image display as a block, and with 100% of the width of its container. This way, we don't have to hardcode px value for the width of images, and it displays correctly on mobile.