### PR TITLE
made amai side by side be the same height on laptop

### DIFF
--- a/_portfolio/amai.html
+++ b/_portfolio/amai.html
@@ -17,7 +17,7 @@ layout: portfolio-item
 <br><br>
 <h1>THE EXPERIENCE</h1>
 
-<div class="two-column-grid">
+<div class="two-column-grid" id="amai-side-by-side">
   <img src="/assets/images/Amai_2.jpg">
   <img src="/assets/images/Amai_3.jpg">
 </div>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -169,6 +169,12 @@ img.rounded {
   }
 }
 
+#amai-side-by-side {
+  @media screen and (min-width: $on-palm) {
+    grid-template-columns: 42.25% 57.75%;
+  }
+}
+
 .three-column-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
I tweaked the column widths of the div with the two amai images so that the heights of the images are the same on laptop. There could be a better way of doing this though, a way that doesn't require figuring out the exact percentage of each column.

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/4406614/60920748-8bf18e80-a25e-11e9-8ebb-a4e2f0750ade.png">
